### PR TITLE
Small cleanup

### DIFF
--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -87,14 +87,11 @@ let all_opam_packages () =
     ]
   >>= deps_of_opam_result
 
-let lib () =
-  Util.lines_of_process "opam" [ "var"; "--switch"; get_switch (); "lib" ]
-  |> List.hd
-
 let prefix () =
   Util.lines_of_process "opam" [ "var"; "--switch"; get_switch (); "prefix" ]
   |> List.hd
 
+(** Relative to [prefix ()]. *)
 let pkg_contents pkg =
   let prefix = prefix () in
   let changes_file = Format.asprintf "%s/.opam-switch/install/%s.changes" prefix pkg in
@@ -102,4 +99,4 @@ let pkg_contents pkg =
   let changed = OpamFile.Changes.read_from_channel ic in
   close_in ic;
   let added = OpamStd.String.Map.fold (fun file x acc -> match x with OpamDirTrack.Added _ -> file :: acc | _ -> acc) changed [] in
-  List.map (fun path -> Fpath.(v prefix // v path)) added
+  List.map Fpath.v added

--- a/lib/prep.ml
+++ b/lib/prep.ml
@@ -13,10 +13,8 @@ open Listm
 
 type source_info = {
   root : Fpath.t; (** Root path in which this was found *)
-  file : Fpath.t; (** Original file *)
+  relpath : Fpath.t; (** Path relative to [root] *)
   name : string; (** 'Astring' *)
-  dir : Fpath.t; (** relative dir below root *)
-  fname : Fpath.t; (* filename with extension *)
   package : Opam.package; (* Package in which this file lives ("astring") *)
   universe : Universe.t
 }
@@ -26,66 +24,68 @@ let top_path = Fpath.v "prep"
 (* Given a base Fpath.t (a cmt, cmti or cmi, without extension), figure out the 'best' one - in order or preference
    cmti, cmt, cmi *)
 
-  
-let is_hidden x =
-  let is_hidden s =
-    let len = String.length s in
-    let rec aux i =
-        if i > len - 2 then false else
-        if s.[i] = '_' && s.[i + 1] = '_' then true
-        else aux (i + 1)
-    in aux 0
+
+(** Get info given a relative path (to [root]) to an object file (cmt, cmti or cmi). *)
+let get_cm_info root package relpath =
+  let _, lname = Fpath.split_base relpath in
+  let name = String.capitalize (Fpath.to_string lname) in
+  try
+    let _, universe = Universe.Current.dep_universe package.Opam.name in
+    Format.eprintf "%a: universe=%a\n%!" Opam.pp_package package Universe.pp
+      universe;
+    [ { root; relpath; name; package; universe } ]
+  with _ -> []
+
+(** Lower is better *)
+let cm_file_preference = function
+  | ".cmti" -> Some 1
+  | ".cmt" -> Some 2
+  | ".cmi" -> Some 3
+  | _ -> None
+
+(** Get cm* files out of a list of files.
+    Given the choice between a cmti, a cmt and a cmi file, we chose them according to [cm_file_preference] above *)
+let get_cm_files files =
+  let rec skip f = function hd :: tl when f hd -> skip f tl | x -> x in
+  (* Take the first of each group. *)
+  let rec dedup acc = function
+    | (base, _, p) :: tl ->
+        let tl = skip (fun (base', _, _) -> base = base') tl in
+        dedup (p :: acc) tl
+    | [] -> acc
   in
-  is_hidden (Fpath.basename x)
+  (* Sort files by their basename and preference, remove other files *)
+  files
+  >>= (fun p ->
+        let without_ext, ext = Fpath.split_ext p in
+        match cm_file_preference ext with
+        | Some pref -> [ (Fpath.basename without_ext, pref, p) ]
+        | None -> [])
+  |> List.sort compare |> dedup []
 
-let package_of_relpath relpath =
-  match Fpath.segs relpath with
-  | pkg :: rest -> pkg, Fpath.split_base (Fpath.v (String.concat Fpath.dir_sep rest))
-  | _ ->
-    Format.eprintf "Invalid path, unable to determine package: %a\n%!" Fpath.pp relpath;
-    failwith "Invalid path"
-
-   let best_source_file base_path =
-    let file_preference = List.map (fun ext -> Fpath.add_ext ext base_path) ["cmti"; "cmt"; "cmi"] in
-    let exists s = try let (_ : Unix.stats) = Unix.stat (Fpath.to_string s) in true with _ -> false in
-    List.find exists file_preference
-  
-  (* Get info given a base file (cmt, cmti or cmi) *)
-  let get_info root package mod_file =
-    let file = best_source_file mod_file in
-    let (_, lname) = Fpath.split_base mod_file in
-    let name = String.capitalize (Fpath.to_string lname) in
-    let relpath = match Fpath.relativize ~root file with Some p -> p | None -> failwith "odd" in
-    let dir, fname = Fpath.split_base relpath in
-    try
-      let (_, universe) = Universe.Current.dep_universe package.Opam.name in
-      Format.eprintf "%a: universe=%a\n%!" Opam.pp_package package Universe.pp universe;
-      [{root; file; name; dir; package; fname; universe}]
-    with _ ->
-      []
+(** A list of [source_info] for each files of a package.
+    Keep only one of the corresponding .cmti, .cmt or .cmi for a module, in
+    that order of preference. *)
+let infos_of_package pkg =
+  let partition_by_kind lib f =
+    let segs = Fpath.segs f in
+    match segs with
+    | "lib" :: _
+      when not (List.mem ".private" segs || List.mem ".coq-native" segs) ->
+        f :: lib
+    | _ -> lib
+  in
+  let lib =
+    List.fold_left partition_by_kind [] (Opam.pkg_contents pkg.Opam.name)
+  in
+  let lib = get_cm_files lib in
+  let prefix = Opam.prefix () |> Fpath.v in
+  List.flatten (List.map (get_cm_info prefix pkg) lib)
 
 let run whitelist _roots =
   let packages = Opam.all_opam_packages () in
   let packages = List.filter (fun pkg -> pkg.Opam.name <> "ocaml-secondary-compiler") packages in
-  let root = Opam.lib () |> Fpath.v in
-  let pkg_contents = List.map (fun pkg ->
-    (pkg, Opam.pkg_contents pkg.Opam.name)) packages in
-
-  let infos =
-    List.map
-      (fun (pkg, files) ->
-        List.filter (Inputs.has_ext ["cmi";"cmt";"cmti"]) files |>
-        List.filter (fun f ->
-          let segs = Fpath.segs f in
-          not (
-            List.mem ".private" segs
-         || List.mem ".coq-native" segs)) |>
-        List.map Fpath.rem_ext |>
-        setify |>
-        List.map (get_info root pkg)) pkg_contents
-    |> List.flatten |> List.flatten
-  in
-
+  let infos = List.flatten (List.map infos_of_package packages) in
 
   let infos =
     if List.length whitelist > 0
@@ -93,14 +93,15 @@ let run whitelist _roots =
     else infos
   in
   let infos =
-    List.filter (fun info -> try ignore (Universe.Current.dep_universe info.package.name); true with _ -> Format.eprintf "pruning %a\n%!" Fpath.pp info.file; false) infos
+    List.filter (fun info -> try ignore (Universe.Current.dep_universe info.package.name); true with _ -> Format.eprintf "pruning %a\n%!" Fpath.pp (Fpath.append info.root info.relpath); false) infos
   in
   let copy info =
     let v_str = Astring.String.cuts ~sep:"." info.package.version in
     let v_str = String.concat "_" v_str in
-    let dest_dir = Fpath.(top_path / "universes" / info.universe.id / info.package.name / v_str // info.dir ) in
-    Util.mkdir_p dest_dir;
-    Util.cp (Format.asprintf "%a" Fpath.pp info.file) (Format.asprintf "%a/%a" Fpath.pp dest_dir Fpath.pp info.fname)
+    let src = Fpath.append info.root info.relpath in
+    let dest = Fpath.(top_path / "universes" / info.universe.id / info.package.name / v_str // info.relpath ) in
+    Util.mkdir_p (Fpath.parent dest);
+    Util.cp src dest
   in
   List.iter copy infos;
   Universe.Current.save top_path

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -31,7 +31,7 @@ let mkdir_p d =
     | Unix.Unix_error (Unix.EEXIST, _, _) -> d
     | exn -> raise exn) (Fpath.v ".") segs in
   ()
-  
+
 let write_file filename lines =
   let dir = fst (Fpath.split_base filename) in
   mkdir_p dir;
@@ -47,5 +47,5 @@ let time txt fn a =
   result
 
 let cp src dst =
-  Format.eprintf "cp: %s -> %s\n%!" src dst;
-  assert (lines_of_process "/bin/cp" [ src; dst ] = [])
+  Format.eprintf "%s -> %s\n%!" src dst;
+  assert (lines_of_process "cp" [ src; dst ] = [])

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -47,5 +47,6 @@ let time txt fn a =
   result
 
 let cp src dst =
+  let src = Fpath.to_string src and dst = Fpath.to_string dst in
   Format.eprintf "%s -> %s\n%!" src dst;
   assert (lines_of_process "cp" [ src; dst ] = [])

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -17,8 +17,8 @@ let lines_of_channel ic =
     with End_of_file -> List.rev acc
   in inner []
 
-let lines_of_process p =
-    let ic = Unix.open_process_in p in
+let lines_of_process prog args =
+    let ic = Unix.open_process_in (Filename.quote_command prog args) in
     protect
       ~finally:(fun () -> ignore(Unix.close_process_in ic))
       (fun () -> lines_of_channel ic)
@@ -48,6 +48,4 @@ let time txt fn a =
 
 let cp src dst =
   Format.eprintf "cp: %s -> %s\n%!" src dst;
-  assert (lines_of_process (Printf.sprintf "/bin/cp %s %s" src dst) = [])
-
-
+  assert (lines_of_process "/bin/cp" [ src; dst ] = [])

--- a/voodoo_prep.ml
+++ b/voodoo_prep.ml
@@ -15,10 +15,6 @@ let conv_compose ?docv parse to_string c =
   conv ~docv (parse, print)
 
 
-(* Just to find the location of all relevant ocaml cmt/cmti/cmis *)
-let read_lib_dir () =
-  Opam.lib ()
-
 module Prep = struct
 
   let switch =


### PR DESCRIPTION
A set of small fixes:
- Improve the algorithm for finding inputs (avoid unecessary IO, simplify handling of paths, check 'lib/' prefix)
- Fix a call to `cp`
- Use a safer API for calling external programs (`Filename.quote_command` instead of `asprintf`)
