### PR TITLE
Add the 'prep-odocmkgen' step

### DIFF
--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -87,14 +87,11 @@ let all_opam_packages () =
     ]
   >>= deps_of_opam_result
 
-let lib () =
-  Util.lines_of_process "opam" [ "var"; "--switch"; get_switch (); "lib" ]
-  |> List.hd
-
 let prefix () =
   Util.lines_of_process "opam" [ "var"; "--switch"; get_switch (); "prefix" ]
   |> List.hd
 
+(** Relative to [prefix ()]. *)
 let pkg_contents pkg =
   let prefix = prefix () in
   let changes_file = Format.asprintf "%s/.opam-switch/install/%s.changes" prefix pkg in
@@ -102,4 +99,4 @@ let pkg_contents pkg =
   let changed = OpamFile.Changes.read_from_channel ic in
   close_in ic;
   let added = OpamStd.String.Map.fold (fun file x acc -> match x with OpamDirTrack.Added _ -> file :: acc | _ -> acc) changed [] in
-  List.map (fun path -> Fpath.(v prefix // v path)) added
+  List.map Fpath.v added

--- a/lib/prep.ml
+++ b/lib/prep.ml
@@ -13,10 +13,8 @@ open Listm
 
 type source_info = {
   root : Fpath.t; (** Root path in which this was found *)
-  file : Fpath.t; (** Original file *)
+  relpath : Fpath.t; (** Path relative to [root] *)
   name : string; (** 'Astring' *)
-  dir : Fpath.t; (** relative dir below root *)
-  fname : Fpath.t; (* filename with extension *)
   package : Opam.package; (* Package in which this file lives ("astring") *)
   universe : Universe.t
 }
@@ -26,66 +24,68 @@ let top_path = Fpath.v "prep"
 (* Given a base Fpath.t (a cmt, cmti or cmi, without extension), figure out the 'best' one - in order or preference
    cmti, cmt, cmi *)
 
-  
-let is_hidden x =
-  let is_hidden s =
-    let len = String.length s in
-    let rec aux i =
-        if i > len - 2 then false else
-        if s.[i] = '_' && s.[i + 1] = '_' then true
-        else aux (i + 1)
-    in aux 0
+
+(** Get info given a relative path (to [root]) to an object file (cmt, cmti or cmi). *)
+let get_cm_info root package relpath =
+  let _, lname = Fpath.split_base relpath in
+  let name = String.capitalize (Fpath.to_string lname) in
+  try
+    let _, universe = Universe.Current.dep_universe package.Opam.name in
+    Format.eprintf "%a: universe=%a\n%!" Opam.pp_package package Universe.pp
+      universe;
+    [ { root; relpath; name; package; universe } ]
+  with _ -> []
+
+(** Lower is better *)
+let cm_file_preference = function
+  | ".cmti" -> Some 1
+  | ".cmt" -> Some 2
+  | ".cmi" -> Some 3
+  | _ -> None
+
+(** Get cm* files out of a list of files.
+    Given the choice between a cmti, a cmt and a cmi file, we chose them according to [cm_file_preference] above *)
+let get_cm_files files =
+  let rec skip f = function hd :: tl when f hd -> skip f tl | x -> x in
+  (* Take the first of each group. *)
+  let rec dedup acc = function
+    | (base, _, p) :: tl ->
+        let tl = skip (fun (base', _, _) -> base = base') tl in
+        dedup (p :: acc) tl
+    | [] -> acc
   in
-  is_hidden (Fpath.basename x)
+  (* Sort files by their basename and preference, remove other files *)
+  files
+  >>= (fun p ->
+        let without_ext, ext = Fpath.split_ext p in
+        match cm_file_preference ext with
+        | Some pref -> [ (Fpath.basename without_ext, pref, p) ]
+        | None -> [])
+  |> List.sort compare |> dedup []
 
-let package_of_relpath relpath =
-  match Fpath.segs relpath with
-  | pkg :: rest -> pkg, Fpath.split_base (Fpath.v (String.concat Fpath.dir_sep rest))
-  | _ ->
-    Format.eprintf "Invalid path, unable to determine package: %a\n%!" Fpath.pp relpath;
-    failwith "Invalid path"
-
-   let best_source_file base_path =
-    let file_preference = List.map (fun ext -> Fpath.add_ext ext base_path) ["cmti"; "cmt"; "cmi"] in
-    let exists s = try let (_ : Unix.stats) = Unix.stat (Fpath.to_string s) in true with _ -> false in
-    List.find exists file_preference
-  
-  (* Get info given a base file (cmt, cmti or cmi) *)
-  let get_info root package mod_file =
-    let file = best_source_file mod_file in
-    let (_, lname) = Fpath.split_base mod_file in
-    let name = String.capitalize (Fpath.to_string lname) in
-    let relpath = match Fpath.relativize ~root file with Some p -> p | None -> failwith "odd" in
-    let dir, fname = Fpath.split_base relpath in
-    try
-      let (_, universe) = Universe.Current.dep_universe package.Opam.name in
-      Format.eprintf "%a: universe=%a\n%!" Opam.pp_package package Universe.pp universe;
-      [{root; file; name; dir; package; fname; universe}]
-    with _ ->
-      []
+(** A list of [source_info] for each files of a package.
+    Keep only one of the corresponding .cmti, .cmt or .cmi for a module, in
+    that order of preference. *)
+let infos_of_package pkg =
+  let partition_by_kind lib f =
+    let segs = Fpath.segs f in
+    match segs with
+    | "lib" :: _
+      when not (List.mem ".private" segs || List.mem ".coq-native" segs) ->
+        f :: lib
+    | _ -> lib
+  in
+  let lib =
+    List.fold_left partition_by_kind [] (Opam.pkg_contents pkg.Opam.name)
+  in
+  let lib = get_cm_files lib in
+  let prefix = Opam.prefix () |> Fpath.v in
+  List.flatten (List.map (get_cm_info prefix pkg) lib)
 
 let run whitelist _roots =
   let packages = Opam.all_opam_packages () in
   let packages = List.filter (fun pkg -> pkg.Opam.name <> "ocaml-secondary-compiler") packages in
-  let root = Opam.lib () |> Fpath.v in
-  let pkg_contents = List.map (fun pkg ->
-    (pkg, Opam.pkg_contents pkg.Opam.name)) packages in
-
-  let infos =
-    List.map
-      (fun (pkg, files) ->
-        List.filter (Inputs.has_ext ["cmi";"cmt";"cmti"]) files |>
-        List.filter (fun f ->
-          let segs = Fpath.segs f in
-          not (
-            List.mem ".private" segs
-         || List.mem ".coq-native" segs)) |>
-        List.map Fpath.rem_ext |>
-        setify |>
-        List.map (get_info root pkg)) pkg_contents
-    |> List.flatten |> List.flatten
-  in
-
+  let infos = List.flatten (List.map infos_of_package packages) in
 
   let infos =
     if List.length whitelist > 0
@@ -93,14 +93,15 @@ let run whitelist _roots =
     else infos
   in
   let infos =
-    List.filter (fun info -> try ignore (Universe.Current.dep_universe info.package.name); true with _ -> Format.eprintf "pruning %a\n%!" Fpath.pp info.file; false) infos
+    List.filter (fun info -> try ignore (Universe.Current.dep_universe info.package.name); true with _ -> Format.eprintf "pruning %a\n%!" Fpath.pp (Fpath.append info.root info.relpath); false) infos
   in
   let copy info =
     let v_str = Astring.String.cuts ~sep:"." info.package.version in
     let v_str = String.concat "_" v_str in
-    let dest_dir = Fpath.(top_path / "universes" / info.universe.id / info.package.name / v_str // info.dir ) in
-    Util.mkdir_p dest_dir;
-    Util.cp (Format.asprintf "%a" Fpath.pp info.file) (Format.asprintf "%a/%a" Fpath.pp dest_dir Fpath.pp info.fname)
+    let src = Fpath.append info.root info.relpath in
+    let dest = Fpath.(top_path / "universes" / info.universe.id / info.package.name / v_str // info.relpath ) in
+    Util.mkdir_p (Fpath.parent dest);
+    Util.cp src dest
   in
   List.iter copy infos;
   Universe.Current.save top_path

--- a/lib/prep.ml
+++ b/lib/prep.ml
@@ -11,30 +11,25 @@ open Listm
   
   *)
 
-type source_info = {
-  root : Fpath.t; (** Root path in which this was found *)
-  relpath : Fpath.t; (** Path relative to [root] *)
-  name : string; (** 'Astring' *)
-  package : Opam.package; (* Package in which this file lives ("astring") *)
-  universe : Universe.t
+type package_info = {
+  package_opam : Opam.package;
+  universe : Universe.t;
 }
+
+type source_info = {
+  root : Fpath.t;  (** Root path in which this was found *)
+  relpath : Fpath.t;  (** Path relative to [root] *)
+  name : string;  (** 'Astring' *)
+  package : package_info; (* Package in which this file lives ("astring") *)
+}
+
 let top_path = Fpath.v "prep"
-
-
-(* Given a base Fpath.t (a cmt, cmti or cmi, without extension), figure out the 'best' one - in order or preference
-   cmti, cmt, cmi *)
-
 
 (** Get info given a relative path (to [root]) to an object file (cmt, cmti or cmi). *)
 let get_cm_info root package relpath =
   let _, lname = Fpath.split_base relpath in
   let name = String.capitalize (Fpath.to_string lname) in
-  try
-    let _, universe = Universe.Current.dep_universe package.Opam.name in
-    Format.eprintf "%a: universe=%a\n%!" Opam.pp_package package Universe.pp
-      universe;
-    [ { root; relpath; name; package; universe } ]
-  with _ -> []
+  try [ { root; relpath; name; package } ] with _ -> []
 
 (** Lower is better *)
 let cm_file_preference = function
@@ -66,7 +61,7 @@ let get_cm_files files =
 (** A list of [source_info] for each files of a package.
     Keep only one of the corresponding .cmti, .cmt or .cmi for a module, in
     that order of preference. *)
-let infos_of_package pkg =
+let infos_of_package package_opam =
   let partition_by_kind lib f =
     let segs = Fpath.segs f in
     match segs with
@@ -75,12 +70,19 @@ let infos_of_package pkg =
         f :: lib
     | _ -> lib
   in
+  let package_name = package_opam.Opam.name in
   let lib =
-    List.fold_left partition_by_kind [] (Opam.pkg_contents pkg.Opam.name)
+    List.fold_left partition_by_kind [] (Opam.pkg_contents package_name)
   in
   let lib = get_cm_files lib in
   let prefix = Opam.prefix () |> Fpath.v in
-  List.flatten (List.map (get_cm_info prefix pkg) lib)
+  let package =
+    let _, universe = Universe.Current.dep_universe package_name in
+    Format.eprintf "%a: universe=%a\n%!" Opam.pp_package package_opam
+      Universe.pp universe;
+    { package_opam; universe }
+  in
+  List.flatten (List.map (get_cm_info prefix package) lib)
 
 let run whitelist _roots =
   let packages = Opam.all_opam_packages () in
@@ -89,17 +91,18 @@ let run whitelist _roots =
 
   let infos =
     if List.length whitelist > 0
-    then List.filter (fun info -> List.mem info.package.name whitelist) infos
+    then List.filter (fun info -> List.mem info.package.package_opam.name whitelist) infos
     else infos
   in
   let infos =
-    List.filter (fun info -> try ignore (Universe.Current.dep_universe info.package.name); true with _ -> Format.eprintf "pruning %a\n%!" Fpath.pp (Fpath.append info.root info.relpath); false) infos
+    List.filter (fun info -> try ignore (Universe.Current.dep_universe info.package.package_opam.name); true with _ -> Format.eprintf "pruning %a\n%!" Fpath.pp (Fpath.append info.root info.relpath); false) infos
   in
   let copy info =
-    let v_str = Astring.String.cuts ~sep:"." info.package.version in
+    let { package_opam; universe } = info.package in
+    let v_str = Astring.String.cuts ~sep:"." package_opam.version in
     let v_str = String.concat "_" v_str in
     let src = Fpath.append info.root info.relpath in
-    let dest = Fpath.(top_path / "universes" / info.universe.id / info.package.name / v_str // info.relpath ) in
+    let dest = Fpath.(top_path / "universes" / universe.id / package_opam.name / v_str // info.relpath ) in
     Util.mkdir_p (Fpath.parent dest);
     Util.cp src dest
   in

--- a/lib/prep_step2.ml
+++ b/lib/prep_step2.ml
@@ -1,0 +1,102 @@
+(** Prepare a "prep" tree for odocmkgen:
+    - Add listing packages (universes, packages in universes, versions of packages)
+    - Add default package page if there is not already one
+    - TODO: Add some informations to user's package pages ?
+      (dependencies to other packages, list of modules and pages)
+    *)
+
+let ( / ) = Fpath.( / )
+
+let fpf = Printf.fprintf
+
+let write_file p f =
+  let out = open_out (Fpath.to_string p) in
+  Format.eprintf "Create '%a'\n" Fpath.pp p;
+  Fun.protect ~finally:(fun () -> close_out out) (fun () -> f out)
+
+let index_page_of_dir d =
+  let parent, base = Fpath.split_base d in
+  Fpath.( // ) parent (Fpath.set_ext ".mld" base)
+
+let is_dir (_, p) = Sys.is_directory (Fpath.to_string p)
+
+let is_hidden s =
+  let len = String.length s in
+  let rec aux i =
+    if i > len - 2 then false
+    else if s.[i] = '_' && s.[i + 1] = '_' then true
+    else aux (i + 1)
+  in
+  aux 0
+
+(** This is an approximation. *)
+let unit_name_of_file_name f =
+  String.capitalize_ascii (Fpath.basename (Fpath.rem_ext (Fpath.v f)))
+
+let modules_of_file_list =
+  List.filter_map (fun (fname, _) ->
+      if is_hidden fname then None else Some (unit_name_of_file_name fname))
+
+let pp_childpages out = List.iter (fpf out "- {!childpage:%s}\n")
+
+let pp_childmodules out = List.iter (fpf out "- {!childmodule:%s}\n")
+
+let gen_universes_list universes out =
+  fpf out
+    "{0 Universes}\n\
+     These universes are for those packages that are compiled against an \
+     alternative set of dependencies than those in the 'packages' hierarchy.\n";
+  pp_childpages out universes;
+  ()
+
+let gen_universe_page universe_name packages out =
+  fpf out
+    "{0 Universe %s}\n\
+     {1 Packages}\n\
+     This dependency universe has been used to compile the following packages:\n"
+    universe_name;
+  pp_childpages out packages;
+  ()
+
+let gen_versions_list pkg_name versions out =
+  fpf out "{0 Package '%s'}\n{1 Versions}\n" pkg_name;
+  pp_childpages out versions;
+  ()
+
+let gen_package_page pkg_name version subpkgs out =
+  let gen_subpkg (name, modules) =
+    fpf out "{1 [%s]}\n" name;
+    pp_childmodules out modules;
+    ()
+  in
+  fpf out "{0 Package '%s' version %s}\n" pkg_name version;
+  List.iter gen_subpkg subpkgs;
+  ()
+
+let prep_package pkg_name version p =
+  let subpkgs =
+    Util.list_dir (Fpath.( / ) p "lib")
+    |> List.filter is_dir
+    |> List.map (fun (s, p') -> (s, modules_of_file_list (Util.list_dir p')))
+  in
+  (* TODO: Detect user's package pages (not yet copied by 'prep') *)
+  write_file (index_page_of_dir p) (gen_package_page pkg_name version subpkgs)
+
+let prep_package_versions pkg_name p =
+  let versions = List.filter is_dir (Util.list_dir p) in
+  write_file (index_page_of_dir p)
+    (gen_versions_list pkg_name (List.map fst versions));
+  List.iter (fun (v, p') -> prep_package pkg_name v p') versions
+
+let prep_universe universe_name p =
+  let packages = List.filter is_dir (Util.list_dir p) in
+  write_file (index_page_of_dir p)
+    (gen_universe_page universe_name (List.map fst packages));
+  List.iter (fun (pkg_name, p') -> prep_package_versions pkg_name p') packages
+
+let prep_universes p =
+  let universes = List.filter is_dir (Util.list_dir p) in
+  write_file (index_page_of_dir p) (gen_universes_list (List.map fst universes));
+  List.iter (fun (name, p') -> prep_universe name p') universes
+
+let run () = prep_universes (Prep.top_path / "universes")

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -31,7 +31,7 @@ let mkdir_p d =
     | Unix.Unix_error (Unix.EEXIST, _, _) -> d
     | exn -> raise exn) (Fpath.v ".") segs in
   ()
-  
+
 let write_file filename lines =
   let dir = fst (Fpath.split_base filename) in
   mkdir_p dir;
@@ -47,5 +47,5 @@ let time txt fn a =
   result
 
 let cp src dst =
-  Format.eprintf "cp: %s -> %s\n%!" src dst;
-  assert (lines_of_process "/bin/cp" [ src; dst ] = [])
+  Format.eprintf "%s -> %s\n%!" src dst;
+  assert (lines_of_process "cp" [ src; dst ] = [])

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -47,5 +47,6 @@ let time txt fn a =
   result
 
 let cp src dst =
+  let src = Fpath.to_string src and dst = Fpath.to_string dst in
   Format.eprintf "%s -> %s\n%!" src dst;
   assert (lines_of_process "cp" [ src; dst ] = [])

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -50,3 +50,10 @@ let cp src dst =
   let src = Fpath.to_string src and dst = Fpath.to_string dst in
   Format.eprintf "%s -> %s\n%!" src dst;
   assert (lines_of_process "cp" [ src; dst ] = [])
+
+let list_dir p =
+  match Sys.readdir (Fpath.to_string p) with
+  | exception Sys_error _ -> []
+  | names ->
+      Array.sort String.compare names;
+      Array.map (fun n -> (n, Fpath.( / ) p n)) names |> Array.to_list

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -17,8 +17,8 @@ let lines_of_channel ic =
     with End_of_file -> List.rev acc
   in inner []
 
-let lines_of_process p =
-    let ic = Unix.open_process_in p in
+let lines_of_process prog args =
+    let ic = Unix.open_process_in (Filename.quote_command prog args) in
     protect
       ~finally:(fun () -> ignore(Unix.close_process_in ic))
       (fun () -> lines_of_channel ic)
@@ -48,6 +48,4 @@ let time txt fn a =
 
 let cp src dst =
   Format.eprintf "cp: %s -> %s\n%!" src dst;
-  assert (lines_of_process (Printf.sprintf "/bin/cp %s %s" src dst) = [])
-
-
+  assert (lines_of_process "/bin/cp" [ src; dst ] = [])

--- a/voodoo_prep.ml
+++ b/voodoo_prep.ml
@@ -15,10 +15,6 @@ let conv_compose ?docv parse to_string c =
   conv ~docv (parse, print)
 
 
-(* Just to find the location of all relevant ocaml cmt/cmti/cmis *)
-let read_lib_dir () =
-  Opam.lib ()
-
 module Prep = struct
 
   let switch =

--- a/voodoo_prep.ml
+++ b/voodoo_prep.ml
@@ -44,17 +44,23 @@ module Prep = struct
   let info = Term.info "prep" ~doc:"Prep a directory tree for compiling"
 end
 
+module Prep_step2 = struct
+  let cmd = Term.(const Prep_step2.run $ const ())
+
+  let info =
+    Term.info "prep-odocmkgen"
+      ~doc:
+        "Add package and listing pages to a prepared directory tree. Must be \
+         called after $(b,prep) and before $(b,odocmkgen)."
+end
 
 let _ =
-  match Term.eval_choice ~err:Format.err_formatter Prep.(cmd,info) [] with
+  match
+    Term.eval_choice ~err:Format.err_formatter
+      Prep.(cmd, info)
+      [ Prep.(cmd, info); Prep_step2.(cmd, info) ]
+  with
   | `Error _ ->
-    Format.pp_print_flush Format.err_formatter ();
-    exit 2
+      Format.pp_print_flush Format.err_formatter ();
+      exit 2
   | _ -> ()
-
-
-
-
-
-
-


### PR DESCRIPTION
This step run on the output of `voodoo_prep prep` and generates listing and package pages.

This doesn't work well yet because it's not passing fine-grained dependencies to odocmkgen.
It is then guessing dependencies based on compile-deps and passing too many `-I` flags to odoc in undeterminated order.
For example, the link "1_7_0" in yojson redirect to mdx/1_7_0.

It is likely that this need to be completely rewritten.